### PR TITLE
refactor: prevent stackoverflow on btn click event

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -35,7 +35,7 @@ const clearFieldValue = () => {
 
 const checkHash = () => {
     if (!hasError) {
-        const valueIsEqual = originalHash.value === fileHash.value;
+        const valueIsEqual = originalHash.value.length && fileHash.value.length && originalHash.value === fileHash.value;
         
         if (valueIsEqual) {
             alert("Everything is fine, the file is safe!! :)");

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -56,14 +56,11 @@ form.addEventListener("submit", (event) => {
 });
 
 btn.addEventListener("click", () => {
-    inputs.forEach(input => {
-
-        validateData(input);
-
-        input.addEventListener("keyup", () => {
-            validateData(input);
-        });
-    });
-
     checkHash();
+});
+
+inputs.forEach(input => {
+    input.addEventListener("keyup", () => {
+        validateData(input);
+    });
 });


### PR DESCRIPTION
when btn was clicked it was generating more and more listeners for input keyup event, because it was inside of the btn listener